### PR TITLE
Enable async for LogbackValve

### DIFF
--- a/src/main/java/com/chattypie/RootConfiguration.java
+++ b/src/main/java/com/chattypie/RootConfiguration.java
@@ -65,6 +65,7 @@ public class RootConfiguration {
 		LogbackValve logbackValve = new LogbackValve();
 		logbackValve.setQuiet(true);
 		logbackValve.setFilename("logback-access.xml");
+		logbackValve.setAsyncSupported(true);
 		tomcat.addContextValves(logbackValve);
 		return tomcat;
 	}


### PR DESCRIPTION
While testing the migration validation endpoint, the connector constantly gave 500 with the response below. It is due to async support being disabled on the logback valve.

```
POST localhost:8081/api/v1/migration/validateSubscription

{
    "timestamp": "2017-12-12T15:11:28.466+0000",
    "status": 500,
    "error": "Internal Server Error",
    "exception": "java.lang.IllegalStateException",
    "message": "Async support must be enabled on a servlet and for all filters involved in async request processing. This is done in Java code using the Servlet API or by adding \"<async-supported>true</async-supported>\" to servlet and filter declarations in web.xml.",
    "path": "/api/v1/migration/validateSubscription"
}
```